### PR TITLE
Refactor: use base yml for configurations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,11 @@ namespace :release do
   desc 'Release the gem'
   task :push do
     version = LinterChanges::VERSION
-    sh "gem build linter_changes.gemspec"
-    sh "git add ."
+    sh 'gem build linter_changes.gemspec'
+    sh 'git add .'
     sh "git commit -m 'Release version #{version}'"
     sh "git tag -a v#{version} -m 'Release version #{version}'"
-    sh "git push origin master --tags"
+    sh 'git push origin master --tags'
     sh "gem push linter_changes-#{version}.gem"
   end
 end

--- a/lib/linter_changes/cli.rb
+++ b/lib/linter_changes/cli.rb
@@ -6,23 +6,22 @@ require_relative 'git_diff'
 require_relative 'logger'
 require_relative 'linter/base'
 require_relative 'linter/rubocop/adapter'
-require 'pry-byebug'
+require_relative 'config'
 
 module LinterChanges
   class CLI < Thor
     class_option :debug, type: :boolean, default: false, desc: 'Enable debug mode'
-    class_option :target_branch, type: :string, default: nil, desc: 'Specify the target branch'
+    class_option :target_branch, type: :string, default: nil,
+                                 desc: 'Specify the target branch, if nil, it will run globally'
     class_option :force_global, type: :boolean, default: false, desc: 'Run all linters on global configuration'
 
+    method_option :linters, type: :array, default: [],
+                            desc: 'Specify linters to run (e.g., rubocop,eslint). If no option provided, will run everything at config file'
     desc 'lint', 'Run linters on changed files'
-    method_option :linters, type: :array, default: [], desc: 'Specify linters to run (e.g., rubocop,eslint)'
-    method_option :config_files, type: :hash, default: {},
-                                 desc: 'Specify config files per linter (e.g., rubocop=.rubocop.yml)'
-    method_option :linter_command, type: :hash, default: {},
-                                   desc: 'Specify command per linter (e.g., rubocop="rubocop --parallel")'
     def lint
       Logger.debug_mode = options[:debug]
 
+      @config = LinterChanges::Config.load
       overall_success = true
 
       select_linters.each do |linter|
@@ -39,11 +38,11 @@ module LinterChanges
 
     no_commands do
       def select_linters
-        linter_names = if options[:linters].empty?
-                         AVAILABLE_LINTERS.keys
-                       else
-                         options[:linters]
-                       end
+        linter_names = @config.keys && options[:linters]
+        if linter_names.empty?
+          Logger.error 'No linters specified on configuration file.'
+          exit 1
+        end
         linter_names.map do |name|
           klass = AVAILABLE_LINTERS[name]
           unless klass
@@ -51,18 +50,11 @@ module LinterChanges
             exit 1
           end
 
-          # Pass custom config files and commands if provided
-          config_files = parse_config_files_option(name)
-          command = options[:linter_command][name]
-          klass.new(config_files:, command:, target_branch: options[:target_branch], force_global: options[:force_global])
+          # TODO: raise if no config files or command found
+          config_files = @config[name]['config_files'] || []
+          command = @config[name]['linter_command']
+          klass.new(config_files:, command:, force_global: options[:force_global])
         end
-      end
-
-      def parse_config_files_option(linter_name)
-        config_files_option = options[:config_files][linter_name]
-        return nil unless config_files_option
-
-        config_files_option.split(',')
       end
     end
 

--- a/lib/linter_changes/cli.rb
+++ b/lib/linter_changes/cli.rb
@@ -11,8 +11,6 @@ require_relative 'config'
 module LinterChanges
   class CLI < Thor
     class_option :debug, type: :boolean, default: false, desc: 'Enable debug mode'
-    class_option :target_branch, type: :string, default: nil,
-                                 desc: 'Specify the target branch, if nil, it will run globally'
     class_option :force_global, type: :boolean, default: false, desc: 'Run all linters on global configuration'
 
     method_option :linters, type: :array, default: [],
@@ -50,7 +48,7 @@ module LinterChanges
             exit 1
           end
 
-          # TODO: raise if no config files or command found
+          # TODO: raise if no command found
           config_files = @config[name]['config_files'] || []
           command = @config[name]['linter_command']
           klass.new(config_files:, command:, force_global: options[:force_global])

--- a/lib/linter_changes/config.rb
+++ b/lib/linter_changes/config.rb
@@ -1,0 +1,18 @@
+# lib/linter_changes/config.rb
+
+require 'yaml'
+
+module LinterChanges
+  class Config
+    USER_CONFIG_PATH = File.join(Dir.pwd, '.linter_changes.yml')
+
+    def self.load
+      user_config = File.exist?(USER_CONFIG_PATH) ? YAML.load_file(USER_CONFIG_PATH) : nil
+      unless user_config
+        raise StandardError.new 'No configuration file provided, you need the file .linter_changes.yml at the base of your proyect'
+      end
+
+      user_config
+    end
+  end
+end

--- a/lib/linter_changes/git_diff.rb
+++ b/lib/linter_changes/git_diff.rb
@@ -4,10 +4,8 @@ require 'open3'
 
 module LinterChanges
   class GitDiff
-    DEFAULT_TARGET_BRANCH = 'origin/master'
-
     def initialize(target_branch: nil)
-      @target_branch = target_branch || ENV['CHANGE_TARGET'] || DEFAULT_TARGET_BRANCH
+      @target_branch = target_branch
     end
 
     def changed_files

--- a/lib/linter_changes/git_diff.rb
+++ b/lib/linter_changes/git_diff.rb
@@ -4,7 +4,7 @@ require 'open3'
 
 module LinterChanges
   class GitDiff
-    def initialize(target_branch: nil)
+    def initialize(target_branch:)
       @target_branch = target_branch
     end
 

--- a/lib/linter_changes/linter/base.rb
+++ b/lib/linter_changes/linter/base.rb
@@ -35,7 +35,7 @@ module LinterChanges
       def run
         if @force_global
           if @target_branch.nil?
-            Logger.debug "[#{name.capitalize}] No git branch provided, forced to run globally."
+            Logger.debug "[#{name.capitalize}] No git branch provided by CHANGE_TARGET enviroment variable, running globally."
           else
             Logger.debug "[#{name.capitalize}] Forced to run globally."
           end

--- a/lib/linter_changes/linter/base.rb
+++ b/lib/linter_changes/linter/base.rb
@@ -5,15 +5,14 @@ module LinterChanges
     class Base
       attr_reader :name
 
-      def initialize(config_files: nil, command: nil, target_branch: nil, force_global: false)
+      def initialize(config_files:, command:, force_global:)
         @name = self.class.name.split('::')[-2].downcase
-        config_file_path = File.expand_path("#{@name}/default_config.yml", __dir__)
-        default_config_file = YAML.load_file(config_file_path)
-        @config_files = config_files || default_config_file['config_files']
-        @command = command || default_config_file['command']
-        @base_command = @command.split(' ').first
-        @git_diff = GitDiff.new(target_branch:)
-        @force_global = force_global
+        @config_files = config_files
+        @command = command
+        @base_command = @command.split(' ').first # used for listing files with in the adaptars
+        @target_branch = ENV['CHANGE_TARGET']
+        @git_diff = GitDiff.new(target_branch: @target_branch)
+        @force_global = force_global || @target_branch.nil?
       end
 
       def changed_files
@@ -27,27 +26,30 @@ module LinterChanges
 
       # Checks if any configuration files have changed
       def config_changed?
-        changed = @config_files.any? do |pattern|
+        @config_files.any? do |pattern|
           changed_files.any? { |file| file.match? Regexp.new(pattern) }
         end
-        changed
       end
 
       # Runs the linter on the specified files
       def run
         if @force_global
-          Logger.debug "#{name.capitalize} forced to run globally."
+          if @target_branch.nil?
+            Logger.debug "[#{name.capitalize}] No git branch provided, forced to run globally."
+          else
+            Logger.debug "[#{name.capitalize}] Forced to run globally."
+          end
           execute_linter(@command)
         elsif config_changed?
-          Logger.debug "#{name.capitalize} configuration changed. Running linter globally."
+          Logger.debug "[#{name.capitalize}] Configuration changed. Running linter globally."
           execute_linter(@command)
         else
           files_to_lint = list_target_files & changed_files
           if files_to_lint.empty?
-            Logger.debug "No files to lint for #{name.capitalize}."
+            Logger.debug "No files to lint for [#{name.capitalize}]."
             true
           else
-            Logger.debug "Linting files with #{name.capitalize}: #{files_to_lint.join(', ')}"
+            Logger.debug "Linting files with [#{name.capitalize}]: #{files_to_lint.join(', ')}"
             execute_linter("#{@command} #{files_to_lint.join(' ')}")
           end
         end
@@ -56,7 +58,7 @@ module LinterChanges
       private
 
       def execute_linter(command)
-        Logger.debug "Executing RuboCop command: #{command}"
+        Logger.debug "[#{name.capitalize}] Executing command: #{command}"
         system(command)
       end
     end

--- a/lib/linter_changes/linter/rubocop/adapter.rb
+++ b/lib/linter_changes/linter/rubocop/adapter.rb
@@ -24,7 +24,7 @@ module LinterChanges
           # TODO: get the location of Gemfile.lock with bundle command
           # Check if Gemfile.lock has changed and contains something related to rubocop
           if changed_files.include?('Gemfile.lock') && @git_diff.changed_lines_contains?(file: 'Gemfile.lock',
-                                                                                        pattern: 'rubocop')
+                                                                                         pattern: 'rubocop')
             Logger.debug 'Something related to rubocop gem version changed in Gemfile.lock'
             return true
           end

--- a/test/rubocop_linter_test.rb
+++ b/test/rubocop_linter_test.rb
@@ -1,10 +1,10 @@
 # test/rubocop_linter_test.rb
 
 require 'test_helper'
-
 class RuboCopLinterTest < Minitest::Test
   context 'LinterChanges::Linter::RuboCop::Adapter' do
     setup do
+      ENV['CHANGE_TARGET'] = 'master'
       LinterChanges::GitDiff.any_instance.stubs(:changed_files).returns(['app/models/user.rb'])
       LinterChanges::GitDiff.any_instance.stubs(:changed_lines_contains?).returns(false)
       result_mock = mock
@@ -12,7 +12,8 @@ class RuboCopLinterTest < Minitest::Test
       target_files_rubocop = ['rubocop.yml', 'app/models/user.rb', 'app/controllers/users_controller.rb']
       Open3.stubs(:capture3).with('bin/rubocop --list-target-files')
            .returns([target_files_rubocop.join("\n"), '', result_mock])
-      @linter = LinterChanges::Linter::RuboCop::Adapter.new target_branch: 'main'
+      @linter = LinterChanges::Linter::RuboCop::Adapter.new command: 'bin/rubocop', force_global: false,
+                                                            config_files: ['rubocop']
     end
 
     # TODO: test gemfile behaviour
@@ -24,7 +25,8 @@ class RuboCopLinterTest < Minitest::Test
     should 'allow custom config files and command' do
       linter = LinterChanges::Linter::RuboCop::Adapter.new(
         config_files: ['custom.yml'],
-        command: 'rubocop --parallel'
+        command: 'rubocop --parallel',
+        force_global: false
       )
       assert_equal ['custom.yml'], linter.instance_variable_get(:@config_files)
       assert_equal 'rubocop --parallel', linter.instance_variable_get(:@command)


### PR DESCRIPTION
It is more convenient to have a single configuration file at the root of the project that includes this gem, rather than passing arguments to the sh command in the pipeline.